### PR TITLE
Rename function to match elixir_uuid's function

### DIFF
--- a/lib/uuid.ex
+++ b/lib/uuid.ex
@@ -8,7 +8,7 @@ defmodule UUID do
 
   def info!(uuid), do: Uniq.UUID.info!(uuid, :keyword)
 
-  defdelegate binary_to_string(uuid), to: Uniq.UUID, as: :to_string
+  defdelegate binary_to_string!(uuid, format \\ :default), to: Uniq.UUID, as: :to_string
 
   defdelegate string_to_binary!(uuid), to: Uniq.UUID
 


### PR DESCRIPTION
The `elixir_uuid` library's function has an exclamation point on it, and has a format argument, as seen here:

https://hexdocs.pm/elixir_uuid/UUID.html#binary_to_string!/2